### PR TITLE
Change the AWS region default constant to read the value from the env…

### DIFF
--- a/lib/ruby_aem_aws/constants.rb
+++ b/lib/ruby_aem_aws/constants.rb
@@ -42,7 +42,7 @@ module RubyAemAws
   end
 
   class Constants
-    REGION_DEFAULT = 'ap-southeast-2'.freeze
+    REGION_DEFAULT = ENV['AWS_DEFAULT_REGION'] || ENV['aws_default_region'] || 'ap-southeast-2'.freeze
     ACCESS_KEY_ID = ENV['AWS_ACCESS_KEY_ID'] || ENV['aws_access_key_id']
     SECRET_ACCESS_KEY = ENV['AWS_SECRET_ACCESS_KEY'] || ENV['aws_scret_access_key']
     PROFILE = ENV['AWS_PROFILE']


### PR DESCRIPTION
I ran into an issue where inspec-aem-aws would not pass the region variable to ruby_aem_aws, causing it to fallback to ap-southeast-1. Because the deployment was on a different region, things like check-readiness-test and Jenkins acceptance tests would file.

I believe reading the region value from the environment before falling back to the hardcoded value, would help customization at earlier deployment steps.