### PR TITLE
Update response only if the events is not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Disabled ELBv2 unit tests until its fixed
-- Fixed AWS Cloudwatch client log  events to return non empty response
 
 ### Fixed
 - Fixed existing unit tests
+- Fixed AWS Cloudwatch client log  events to return non empty response
 
 ## [2.3.1] - 2022-09-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Disabled ELBv2 unit tests until its fixed
+- Fixed AWS Cloudwatch client log  events to return non empty response
 
 ### Fixed
 - Fixed existing unit tests

--- a/lib/ruby_aem_aws/client/cloudwatch.rb
+++ b/lib/ruby_aem_aws/client/cloudwatch.rb
@@ -52,7 +52,8 @@ module RubyAemAws
       until curr_response.next_token.nil?
         next_token = { next_token: curr_response.next_token }
         filter.update(next_token)
-        response = curr_response
+        # empty events should be ignored
+        response = curr_response unless curr_response.events.empty?
         curr_response = cloud_watch_log_client.filter_log_events(filter)
       end
 


### PR DESCRIPTION
### Fixed
- Fixed AWS Cloudwatch client log  events to return non empty response
