### PR TITLE
Fixed AWS Cloudwatch client log  events to return non empty response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [Unreleased]
+### Fixed
+- Fixed AWS Cloudwatch client log  events to return non empty response
 
 ## [2.2.1] - 2021-12-02
 ### Fixed

--- a/lib/ruby_aem_aws/client/cloudwatch.rb
+++ b/lib/ruby_aem_aws/client/cloudwatch.rb
@@ -52,7 +52,8 @@ module RubyAemAws
       until curr_response.next_token.nil?
         next_token = { next_token: curr_response.next_token }
         filter.update(next_token)
-        response = curr_response
+        # empty events should be ignored
+        response = curr_response unless curr_response.events.empty?
         curr_response = cloud_watch_log_client.filter_log_events(filter)
       end
 


### PR DESCRIPTION
### Fixed
- Fixed AWS Cloudwatch client log  events to return non empty response
